### PR TITLE
EVA-1244 — Fix duplicates in the unique_association_fields

### DIFF
--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -199,6 +199,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
         else:
             self.gene_2_var_func_consequence = 'http://purl.obolibrary.org/obo/' + \
                                                most_severe_so_term.accession.replace(':', '_')
+        self.add_unique_association_field('functional_consequence', self.gene_2_var_func_consequence)
 
         if len(ref_list) > 0:
             self.set_var_2_disease_literature(ref_list)

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -86,6 +86,7 @@ class CTTVEvidenceString(dict):
 
         self.disease_id = trait.ontology_id
         self.add_unique_association_field('phenotype', trait.ontology_id)
+        self.add_unique_association_field('phenotype_source_name', trait.clinvar_name)
 
         if trait.clinvar_name:
             self.disease_source_name = trait.clinvar_name

--- a/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
+++ b/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
@@ -1,7 +1,8 @@
 {
   "access_level": "public",
   "disease": {
-    "id": "http://www.orpha.net/ORDO/Orphanet_88991"
+    "id": "http://www.orpha.net/ORDO/Orphanet_88991",
+    "source_name": "ClinVar name of a mock trait"
   },
   "evidence": {
     "gene2variant": {
@@ -126,8 +127,10 @@
   "unique_association_fields": {
     "alleleOrigin": "germline",
     "clinvarAccession": "RCV000002127",
+    "functional_consequence": "http://purl.obolibrary.org/obo/SO_0001583",
     "gene": "ENSG00000139988",
     "phenotype": "http://www.orpha.net/ORDO/Orphanet_88991",
+    "phenotype_source_name": "ClinVar name of a mock trait",
     "variant_id": "rs28940313"
   },
   "validated_against_schema_version": "1.6.6",

--- a/tests/evidence_string_generation/resources/expected_somatic_evidence_string.json
+++ b/tests/evidence_string_generation/resources/expected_somatic_evidence_string.json
@@ -1,7 +1,8 @@
 {
   "access_level": "public",
   "disease": {
-    "id": "http://www.orpha.net/ORDO/Orphanet_88991"
+    "id": "http://www.orpha.net/ORDO/Orphanet_88991",
+    "source_name": "ClinVar name of a mock trait"
   },
   "evidence": {
     "clinical_significance": "Pathogenic",
@@ -92,6 +93,7 @@
     "clinvarAccession": "RCV000002127",
     "gene": "ENSG00000139988",
     "phenotype": "http://www.orpha.net/ORDO/Orphanet_88991",
+    "phenotype_source_name": "ClinVar name of a mock trait",
     "variant_id": "rs28940313"
   },
   "validated_against_schema_version": "1.6.6"

--- a/tests/evidence_string_generation/test_evidence_strings.py
+++ b/tests/evidence_string_generation/test_evidence_strings.py
@@ -20,7 +20,7 @@ def get_input_data_for_evidence_string_generation():
 
     trait = SimpleNamespace()
     trait.trait_counter = 0
-    trait.clinvar_name = ''
+    trait.clinvar_name = 'ClinVar name of a mock trait'
     trait.ontology_id = 'http://www.orpha.net/ORDO/Orphanet_88991'
     trait.ontology_label = None
 


### PR DESCRIPTION
A tentative solution. Needs to be confirmed with Open Targets. See https://github.com/opentargets/platform/issues/1013 and https://github.com/opentargets/platform/issues/1014.