### PR TITLE
EVA-2019 — Remove the gene2variant resource_score

### DIFF
--- a/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
+++ b/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
@@ -77,13 +77,6 @@
           "status": true
         }
       },
-      "resource_score": {
-        "type": "pvalue",
-        "method": {
-          "description": "Not provided by data supplier"
-        },
-        "value": 1e-7
-      },
       "functional_consequence": null,
       "date_asserted": null
     }

--- a/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
+++ b/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
@@ -26,13 +26,6 @@
           "status": true
         }
       },
-      "resource_score": {
-        "method": {
-          "description": "Not provided by data supplier"
-        },
-        "type": "pvalue",
-        "value": 1e-07
-      },
       "urls": [
         {
           "nice_name": "Further details in ClinVar database",


### PR DESCRIPTION
Closes #121.

Removes the gene2variant → resource_score section in the evidence strings which was added in August 2019 for compatibility with the updates in OT JSON schema. Since then, the schema was modified, making this field (with placeholder values) unnecessary and even detrimental. As per discussions with Asier, this will be removed.

@jmmut @tcezard The review required is not so much of the actual change, but of the discussion history in the Open Targets ticket: https://github.com/opentargets/platform/issues/1138