### PR TITLE
EVA-2106 — Refactor approach to ZOOMA feedback

### DIFF
--- a/bin/trait_mapping/create_table_for_manual_curation.py
+++ b/bin/trait_mapping/create_table_for_manual_curation.py
@@ -36,15 +36,16 @@ if __name__ == '__main__':
         help='Table with traits for which the pipeline failed to make a confident prediction')
     parser.add_argument(
         '-m', '--previous-mappings',
-        help='Table with all mappings previously issued by EVA')
+        help='Table with all mappings previously issued by EVA. TSV with columns: ClinVar trait name; ontology URI; '
+             'ontology label (not used)')
     parser.add_argument(
         '-o', '--output',
         help='Output TSV to be loaded in Google Sheets for manual curation')
     args = parser.parse_args()
     outfile = open(args.output, 'w')
 
-    # Load all previous mappings
-    previous_mappings = dict(l.rstrip().split('\t') for l in open(args.previous_mappings))
+    # Load all previous mappings: ClinVar trait name to ontology URI
+    previous_mappings = dict(line.rstrip().split('\t')[:2] for line in open(args.previous_mappings))
 
     # Process all mappings which require manual curation
     for line in open(args.traits_for_curation):

--- a/docs/generate-evidence-strings.md
+++ b/docs/generate-evidence-strings.md
@@ -202,7 +202,7 @@ The idea with [ZOOMA](http://www.ebi.ac.uk/spot/zooma/) is that we not only use 
 1. **clinvar_xrefs.** ClinVar data already includes some cross-links from trait names to disease ontologies. Unfortunately, it almost exclusively uses MedGen and OMIM, which are not acceptable for Open Targets (since they're using EFO). However, mappings from trait names to MedGen and OMIM might still be useful to other users. Hence, we extract and submit them to ZOOMA under the evidence handle “ClinVar_xRefs”.
 1. **eva_clinvar.** This contains the trait mappings (to EFO) created during the evidence string generation, including automated and manual mappings.
 
-You need to upload two files to the FTP as feedback to ZOOMA: `clinvar_xrefs` and `eva_clinvar`.
+The files are uploaded to the FTP, where ZOOMA will pick it up. At this stage, you only need to upload the **clinvar_xrefs** dataset (the *eva_clinvar* dataset is updated in the process of the manual curation).
 
 To make changes to the FTP, you will need to log in to the cluster using your **personal account** and then run `become <FTP administrative user> /bin/bash`. (Please see [this document](https://www.ebi.ac.uk/seqdb/confluence/display/VAR/Simplified+EVA+FTP+SOP) for details on the FTP administrative user.) After you do this, the environment will be wiped clean, so you will need to set the `BATCH_ROOT` variable again.
 
@@ -212,28 +212,15 @@ To make changes to the FTP, you will need to log in to the cluster using your **
 export BATCH_ROOT=...
 export FTP_PATH_BASE=...
 
-# Create the folder
-
+# Create the folder, copy the file to FTP, and update the “latest” folder
 FTP_PATH=${FTP_PATH_BASE}/`date +%Y/%m/%d`
 mkdir -p ${FTP_PATH}
-
-# Copy both files to FTP
-cp ${BATCH_ROOT}/clinvar/clinvar_xrefs.txt ${BATCH_ROOT}/evidence_strings/eva_clinvar.txt ${FTP_PATH}
-
-# Update files in the “latest” folder
-for ZOOMA_FILE in clinvar_xrefs eva_clinvar; do
-    # ln -f -s ${FTP_PATH}/${ZOOMA_FILE}.txt ${FTP_PATH_BASE}/latest/${ZOOMA_FILE}.txt
-    # # Note: as of August 2019, for some reason symbolic links aren't working consistently; using copying for now
-    cp ${FTP_PATH}/${ZOOMA_FILE}.txt ${FTP_PATH_BASE}/latest/${ZOOMA_FILE}.txt
-done
+cp ${BATCH_ROOT}/clinvar/clinvar_xrefs.txt ${FTP_PATH}
+cp ${FTP_PATH}/clinvar_xrefs.txt ${FTP_PATH_BASE}/latest/clinvar_xrefs.txt
 ```
 
 After uploading both files, confirm that the changes have propagated to the FTP:
 ```bash
-md5sum ${BATCH_ROOT}/evidence_strings/eva_clinvar.txt
-wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/latest/eva_clinvar.txt | md5sum
-wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/`date +%Y/%m/%d`/eva_clinvar.txt | md5sum
-
 md5sum ${BATCH_ROOT}/clinvar/clinvar_xrefs.txt
 wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/`date +%Y/%m/%d`/clinvar_xrefs.txt | md5sum
 wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/latest/clinvar_xrefs.txt | md5sum

--- a/docs/manual-curation/step1-fetch-clinvar-data.md
+++ b/docs/manual-curation/step1-fetch-clinvar-data.md
@@ -23,15 +23,10 @@ cd ${CODE_ROOT} && ${BSUB_CMDLINE} -K -M 4G \
   -o ${CURATION_RELEASE_ROOT}/automated_trait_mappings.tsv \
   -c ${CURATION_RELEASE_ROOT}/traits_requiring_curation.tsv
 
-# Download the latest eva_clinvar release from FTP. At this step, mappings produced by the pipeline on the previous
-# iteration (including automated and manual) are downloaded to be used to aid the manual curation process.
-wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/latest/eva_clinvar.txt \
-  | cut -f4-5 | sort -u > ${CURATION_RELEASE_ROOT}/previous_mappings.tsv
-
 # Create the final table for manual curation
 cd ${CODE_ROOT} && python3 bin/trait_mapping/create_table_for_manual_curation.py \
   --traits-for-curation ${CURATION_RELEASE_ROOT}/traits_requiring_curation.tsv \
-  --previous-mappings ${CURATION_RELEASE_ROOT}/previous_mappings.tsv \
+  --previous-mappings ${BATCH_ROOT_BASE}/manual_curation/latest_mappings.tsv \
   --output ${CURATION_RELEASE_ROOT}/table_for_manual_curation.tsv
 
 # Sort and export to Google Sheets. Note that the number of columns in the output table is limited to 50, because only a

--- a/docs/manual-curation/step3-export-results.md
+++ b/docs/manual-curation/step3-export-results.md
@@ -1,4 +1,4 @@
-# Manual curation, part III, technical: export curation results
+# Manual curation, part III, technical: export curation results and submit feedback to ZOOMA
 
 Before running, set up the environment:
 * [Common environment](../environment.md)
@@ -52,3 +52,26 @@ python3 ${CODE_ROOT}/bin/trait_mapping/create_efo_table.py \
 
 ## Copy the table for EFO import
 The file `${CURATION_RELEASE_ROOT}/efo_import_table.tsv` will contain a partially ready table for EFO import. Copy its contents into the “Add EFO disease” sheet in the curation spreadsheet.
+
+## Submit feedback to ZOOMA
+See more details on ZOOMA feedback in the [evidence string generation protocol](../generate-evidence-strings.md#submit-feedback-to-zooma). At this stage, only the **eva_clinvar** dataset is being submitted; clinvar_xrefs is submitted during evidence string generation.
+
+```bash
+# EXECUTE UNDER FTP ADMINISTRATIVE USER
+# DON'T FORGET TO SET THE TWO VARIABLES BELOW AGAIN
+export BATCH_ROOT_BASE=...
+export FTP_PATH_BASE=...
+
+# Create the folder, copy the file to FTP, and update the “latest” folder
+FTP_PATH=${FTP_PATH_BASE}/`date +%Y/%m/%d`
+mkdir -p ${FTP_PATH}
+cp ${BATCH_ROOT_BASE}/manual_curation/eva_clinvar.txt ${FTP_PATH}
+cp ${FTP_PATH}/eva_clinvar.txt ${FTP_PATH_BASE}/latest/eva_clinvar.txt
+```
+
+After uploading both files, confirm that the changes have propagated to the FTP:
+```bash
+md5sum ${BATCH_ROOT_BASE}/manual_curation/eva_clinvar.txt
+wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/`date +%Y/%m/%d`/eva_clinvar.txt | md5sum
+wget -qO- ftp://ftp.ebi.ac.uk/pub/databases/eva/ClinVar/latest/eva_clinvar.txt | md5sum
+```

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -117,57 +117,9 @@ class Report:
                 fdw.write(str(trait_list) + '\t' +
                           str(self.unmapped_traits[trait_list]) + '\n')
 
-        self.write_zooma_file(dir_out)
-
-    def write_zooma_file(self, dir_out):
-        """Write zooma records to zooma file"""
-        with utilities.open_file(os.path.join(dir_out, config.ZOOMA_FILE_NAME), "wt") as zooma_fh:
-
-            zooma_fh.write("STUDY\tBIOENTITY\tPROPERTY_TYPE\tPROPERTY_VALUE\tSEMANTIC_TAG\tANNOTATOR\tANNOTATION_DATE\n")
-            date = strftime("%d/%m/%y %H:%M", gmtime())
-            for evidence_record in self.evidence_list:
-                self.write_zooma_record_to_zooma_file(evidence_record, zooma_fh, date)
-
-            for trait_name, ontology_tuple_list in self.trait_mappings.items():
-                self.write_extra_trait_to_zooma_file(ontology_tuple_list, trait_name, date, zooma_fh)
-
-    def write_zooma_record_to_zooma_file(self, evidence_record, zooma_fh, date):
-        """Write an zooma record to zooma file"""
-        evidence_record_to_output = ['.' if ele is None else ele for ele in evidence_record]
-
-        if evidence_record_to_output[1] != ".":
-            rs_for_zooma = evidence_record_to_output[1]
-        else:
-            rs_for_zooma = ""
-
-        zooma_output_list = [evidence_record_to_output[0],
-                             rs_for_zooma,
-                             "disease",
-                             evidence_record_to_output[2],
-                             evidence_record_to_output[3],
-                             "eva",
-                             date]
-
-        zooma_fh.write('\t'.join(zooma_output_list) + '\n')
-
-    def write_extra_trait_to_zooma_file(self, ontology_tuple_list, trait_name, date, zooma_fh):
-        """Write the trait name to ontology mappings, which weren't used in any evidence string, to
-        zooma file """
-        for ontology_tuple in ontology_tuple_list:
-            zooma_output_list = ["",
-                                 "",
-                                 "disease",
-                                 trait_name,
-                                 ontology_tuple[0],
-                                 "eva",
-                                 date]
-
-            zooma_fh.write('\t'.join(zooma_output_list) + '\n')
-
     def remove_trait_mapping(self, trait_name):
         if trait_name in self.trait_mappings:
             del self.trait_mappings[trait_name]
-
 
     @staticmethod
     def __get_counters():

--- a/eva_cttv_pipeline/evidence_string_generation/config.py
+++ b/eva_cttv_pipeline/evidence_string_generation/config.py
@@ -1,7 +1,6 @@
 # output settings
 EVIDENCE_STRINGS_FILE_NAME = 'evidence_strings.json'
 EVIDENCE_RECORDS_FILE_NAME = 'evidence_records.tsv'
-ZOOMA_FILE_NAME = 'eva_clinvar.txt'
 UNMAPPED_TRAITS_FILE_NAME = 'unmappedTraits.tsv'
 UNAVAILABLE_EFO_FILE_NAME = 'unavailableefo.tsv'
 NSV_LIST_FILE = 'nsvlist.txt'


### PR DESCRIPTION
* Move creation of the eva_clinvar dataset from evidence string generation to manual curation
* Move submitting eva_clinvar feedback to ZOOMA from evidence string generation to manual curation
* Use previous mappings directly instead of ZOOMA feedback files

Closes #137 (details of the issue are also described there).