### PR TITLE
Add ClinVar star rating and review status

### DIFF
--- a/compare-evidence-strings/compare.sh
+++ b/compare-evidence-strings/compare.sh
@@ -12,12 +12,9 @@ echo "Defining functions"
 # * date_asserted
 # The two arguments are input and output JSON files.
 sort_keys () {
-  jq -S "." --tab <"$1" \
-    | tr -d '\t\n' \
-    | sed -e 's|}{|}~{|g' \
-    | tr '~' '\n' \
-    | sed -e 's|,"validated_against_schema_version": "[0-9.]*"||g' \
-    | sed -e 's|"date_asserted": ".\{19\}",||g' \
+  jq -c -S "." <"$1" \
+    | sed -e 's|,"validated_against_schema_version":"[0-9.]*"||g' \
+    | sed -e 's|"date_asserted":".\{19\}",||g' \
   > "$2"
 }
 

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar.py
@@ -10,12 +10,17 @@ class ClinvarRecord(UserDict):
     # A score for the review status of the assigned clinical significance ranges from 0 to 4 and corresponds to the
     # number of "gold stars" displayed on ClinVar website. See details here:
     # https://www.ncbi.nlm.nih.gov/clinvar/docs/details/#review_status
+    # TODO: the mapping back from uppercase-underscore to lowercase-space wording is required because we still use the
+    # TODO: Java XML parser, which loses the original values. Once we get rid of it (see issue #144), this can be
+    # TODO: removed.
     score_map = {
-        "CRITERIA_PROVIDED_SINGLE_SUBMITTER": 1,
-        "CRITERIA_PROVIDED_CONFLICTING_INTERPRETATIONS": 1,
-        "CRITERIA_PROVIDED_MULTIPLE_SUBMITTERS_NO_CONFLICTS": 2,
-        "REVIEWED_BY_EXPERT_PANEL": 3,
-        "PRACTICE_GUIDELINE": 4,
+        "NO_ASSERTION_PROVIDED": (0, 'no assertion provided'),
+        "NO_ASSERTION_CRITERIA_PROVIDED": (0, 'no assertion criteria provided'),
+        "CRITERIA_PROVIDED_SINGLE_SUBMITTER": (1, 'criteria provided, single submitter'),
+        "CRITERIA_PROVIDED_CONFLICTING_INTERPRETATIONS": (1, 'criteria provided, conflicting interpretations'),
+        "CRITERIA_PROVIDED_MULTIPLE_SUBMITTERS_NO_CONFLICTS": (2, 'criteria provided, multiple submitters, no conflicts'),
+        "REVIEWED_BY_EXPERT_PANEL": (3, 'reviewed by expert panel'),
+        "PRACTICE_GUIDELINE": (4, 'practice guideline'),
     }
 
     def __init__(self, cellbase_dict):
@@ -50,10 +55,8 @@ class ClinvarRecord(UserDict):
 
     @property
     def score(self):
-        """Returns a score for the review status of the assigned clinical significance. See score_map above. It should
-        be noted that currently this property is not used, but this might change in the future.
-        """
-        return self.score_map.get(self.data['referenceClinVarAssertion']['clinicalSignificance']['reviewStatus'], 0)
+        """Returns a (star rating, review status) tuple for the assigned clinical significance. See score_map above."""
+        return self.score_map[self.data['referenceClinVarAssertion']['clinicalSignificance']['reviewStatus']]
 
     @property
     def accession(self):

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -344,6 +344,10 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
         if clinvar_record.clinical_significance:
             self.clinical_significance = process_clinical_significance(clinvar_record.clinical_significance)
 
+        # Populate star rating and review status
+        star_rating, review_status = clinvar_record.score
+        self.clinvar_rating = (star_rating, review_status)
+
     @property
     def db_xref_url(self):
         return self['evidence']['provenance_type']['database']['dbxref']['url']
@@ -409,6 +413,18 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
     @clinical_significance.setter
     def clinical_significance(self, clinical_significance):
         self['evidence']['clinical_significance'] = clinical_significance
+
+    @property
+    def clinvar_rating(self):
+        return self['evidence']['clinvar_rating']
+
+    @clinvar_rating.setter
+    def clinvar_rating(self, clinvar_rating_data):
+        star_rating, review_status = clinvar_rating_data
+        self['evidence']['clinvar_rating'] = {
+            'star_rating': star_rating,
+            'review_status': review_status,
+        }
 
 
 def get_ensembl_gene_id_uri(ensembl_gene_id):

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -186,6 +186,10 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
         if clinvar_record.clinical_significance:
             self.clinical_significance = process_clinical_significance(clinvar_record.clinical_significance)
 
+        # Populate star rating and review status
+        star_rating, review_status = clinvar_record.score
+        self.clinvar_rating = (star_rating, review_status)
+
     @property
     def db_xref_url(self):
         if self['evidence']['gene2variant']['provenance_type']['database']['dbxref']['url'] \
@@ -282,6 +286,18 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
     @clinical_significance.setter
     def clinical_significance(self, clinical_significance):
         self['evidence']['variant2disease']['clinical_significance'] = clinical_significance
+
+    @property
+    def clinvar_rating(self):
+        return self['evidence']['variant2disease']['clinvar_rating']
+
+    @clinvar_rating.setter
+    def clinvar_rating(self, clinvar_rating_data):
+        star_rating, review_status = clinvar_rating_data
+        self['evidence']['variant2disease']['clinvar_rating'] = {
+            'star_rating': star_rating,
+            'review_status': review_status,
+        }
 
 
 class CTTVSomaticEvidenceString(CTTVEvidenceString):

--- a/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
+++ b/eva_cttv_pipeline/evidence_string_generation/resources/CTTVGeneticsEvidenceString.json
@@ -50,7 +50,8 @@
         "value": 1e-7
       },
       "unique_experiment_reference": "http://europepmc.org/abstract/MED/0",
-      "date_asserted": null
+      "date_asserted": null,
+      "clinvar_rating": {}
     },
     "gene2variant": {
       "is_associated": true,

--- a/eva_cttv_pipeline/evidence_string_generation/resources/CTTVSomaticEvidenceString.json
+++ b/eva_cttv_pipeline/evidence_string_generation/resources/CTTVSomaticEvidenceString.json
@@ -42,6 +42,7 @@
       "type": "probability",
       "value": 1
     },
-    "date_asserted": null
+    "date_asserted": null,
+    "clinvar_rating": {}
   }
 }

--- a/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
+++ b/tests/evidence_string_generation/resources/expected_genetics_evidence_string.json
@@ -37,6 +37,10 @@
       "clinical_significance": [
         "pathogenic"
       ],
+      "clinvar_rating": {
+        "review_status": "no assertion criteria provided",
+        "star_rating": 0
+      },
       "date_asserted": "2019-08-28T23:00:00",
       "evidence_codes": [
         "http://purl.obolibrary.org/obo/ECO_0000205"

--- a/tests/evidence_string_generation/resources/expected_somatic_evidence_string.json
+++ b/tests/evidence_string_generation/resources/expected_somatic_evidence_string.json
@@ -7,6 +7,10 @@
     "clinical_significance": [
       "pathogenic"
     ],
+    "clinvar_rating": {
+      "review_status": "no assertion criteria provided",
+      "star_rating": 0
+    },
     "date_asserted": "2019-08-28T23:00:00",
     "evidence_codes": [
       "http://purl.obolibrary.org/obo/ECO_0000205"

--- a/tests/evidence_string_generation/test_clinvar.py
+++ b/tests/evidence_string_generation/test_clinvar.py
@@ -21,7 +21,7 @@ class TestClinvarRecord(unittest.TestCase):
                          datetime.utcfromtimestamp(1567033200000/1000).isoformat())
 
     def test_score(self):
-        self.assertEqual(self.test_clinvar_record.score, 0)
+        self.assertEqual(self.test_clinvar_record.score, (0, 'no assertion criteria provided'))
 
     def test_acc(self):
         self.assertEqual(self.test_clinvar_record.accession, "RCV000002127")


### PR DESCRIPTION
Closes #124. Built on top of #146 and includes all changes from it. More details: https://github.com/opentargets/platform/issues/1137.

The ClinVar star rating (from 0 to 4) and the review status (one of a few possible values) are now extracted from ClinVar and added to the evidence strings. Because of how evidence this represented (see https://github.com/opentargets/platform/issues/1137#issuecomment-663633967 and https://github.com/opentargets/platform/issues/1137#issuecomment-683728359), the values are only output for germline mutations. Further discussion with OT about this pending.

Also submitted a PR to improve the OT JSON schema, details: https://github.com/opentargets/json_schema/pull/96

Also also, fixed a memory leak & removed unnecessary code complexity in the evidence string comparison protocol.