### PR TITLE
Include mode of inheritance

### DIFF
--- a/clinvar-variant-types/clinvar-variant-types.py
+++ b/clinvar-variant-types/clinvar-variant-types.py
@@ -115,8 +115,12 @@ for event, elem in ElementTree.iterparse(gzip.open(args.clinvar_xml)):
             ))
 
             # Mode of inheritance
-            mode_of_inheritance = find_attribute(
-                rcv, 'AttributeSet/Attribute[@Type="ModeOfInheritance"]', 'ModeOfInheritance')
+            mode_of_inheritance_xpath = 'AttributeSet/Attribute[@Type="ModeOfInheritance"]'
+            mode_of_inheritance = find_attribute(rcv, mode_of_inheritance_xpath, 'ModeOfInheritance')
+            if mode_of_inheritance.endswith('multiple'):
+                # Having multiple ModeOfInheritance is rare. Log them for further investigation
+                all_modes = '|'.join(sorted(mode.text for mode in rcv.findall(mode_of_inheritance_xpath)))
+                print(f'Multiple ModeOfInheritance: {all_modes}')
             add_transitions(inheritance_mode_transitions, (
                 'Variant',
                 mode_of_inheritance if mode_of_inheritance.endswith('missing') else 'ModeOfInheritance present',

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar.py
@@ -60,14 +60,12 @@ class ClinvarRecord(UserDict):
 
     @property
     def mode_of_inheritance(self):
-        """Returns a mode of inheritance for a given ClinVar record, if present, and None otherwise."""
-        mode_of_inheritance = None
-        for attribute in self.data['referenceClinVarAssertion'].get('attributeSet', []):
-            if attribute['attribute']['type'] == 'ModeOfInheritance':
-                if mode_of_inheritance:
-                    raise AssertionError('Multiple ModeOfInheritance attributes found')
-                mode_of_inheritance = attribute['attribute']['value']
-        return mode_of_inheritance
+        """Returns a (possibly empty) list of modes of inheritance for a given ClinVar record."""
+        return sorted({
+            attribute['attribute']['value']
+            for attribute in self.data['referenceClinVarAssertion'].get('attributeSet', [])
+            if attribute['attribute']['type'] == 'ModeOfInheritance'
+        })
 
     @property
     def accession(self):

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar.py
@@ -63,10 +63,10 @@ class ClinvarRecord(UserDict):
         """Returns a mode of inheritance for a given ClinVar record, if present, and None otherwise."""
         mode_of_inheritance = None
         for attribute in self.data['referenceClinVarAssertion'].get('attributeSet', []):
-            if attribute['type'] == 'ModeOfInheritance':
+            if attribute['attribute']['type'] == 'ModeOfInheritance':
                 if mode_of_inheritance:
                     raise AssertionError('Multiple ModeOfInheritance attributes found')
-                mode_of_inheritance = attribute['value']
+                mode_of_inheritance = attribute['attribute']['value']
         return mode_of_inheritance
 
     @property

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar.py
@@ -59,6 +59,17 @@ class ClinvarRecord(UserDict):
         return self.score_map[self.data['referenceClinVarAssertion']['clinicalSignificance']['reviewStatus']]
 
     @property
+    def mode_of_inheritance(self):
+        """Returns a mode of inheritance for a given ClinVar record, if present, and None otherwise."""
+        mode_of_inheritance = None
+        for attribute in self.data['referenceClinVarAssertion'].get('attributeSet', []):
+            if attribute['type'] == 'ModeOfInheritance':
+                if mode_of_inheritance:
+                    raise AssertionError('Multiple ModeOfInheritance attributes found')
+                mode_of_inheritance = attribute['value']
+        return mode_of_inheritance
+
+    @property
     def accession(self):
         return self.data['referenceClinVarAssertion']['clinVarAccession']['acc']
 

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -190,6 +190,11 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
         star_rating, review_status = clinvar_record.score
         self.clinvar_rating = (star_rating, review_status)
 
+        # Populate mode of inheritance (if present)
+        mode_of_inheritance = clinvar_record.mode_of_inheritance
+        if mode_of_inheritance:
+            self.mode_of_inheritance = mode_of_inheritance
+
     @property
     def db_xref_url(self):
         if self['evidence']['gene2variant']['provenance_type']['database']['dbxref']['url'] \

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -360,6 +360,9 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
         star_rating, review_status = clinvar_record.score
         self.clinvar_rating = (star_rating, review_status)
 
+        # Populate mode of inheritance (if present)
+        self.mode_of_inheritance = clinvar_record.mode_of_inheritance
+
     @property
     def db_xref_url(self):
         return self['evidence']['provenance_type']['database']['dbxref']['url']
@@ -437,6 +440,15 @@ class CTTVSomaticEvidenceString(CTTVEvidenceString):
             'star_rating': star_rating,
             'review_status': review_status,
         }
+
+    @property
+    def mode_of_inheritance(self):
+        return self['evidence'].get('mode_of_inheritance')
+
+    @mode_of_inheritance.setter
+    def mode_of_inheritance(self, mode_of_inheritance):
+        if mode_of_inheritance:
+            self['evidence']['mode_of_inheritance'] = mode_of_inheritance
 
 
 def get_ensembl_gene_id_uri(ensembl_gene_id):

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -299,6 +299,14 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
             'review_status': review_status,
         }
 
+    @property
+    def mode_of_inheritance(self):
+        return self['evidence']['variant2disease'].get('mode_of_inheritance')
+
+    @mode_of_inheritance.setter
+    def mode_of_inheritance(self, mode_of_inheritance):
+        self['evidence']['variant2disease']['mode_of_inheritance'] = mode_of_inheritance
+
 
 class CTTVSomaticEvidenceString(CTTVEvidenceString):
 

--- a/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/evidence_strings.py
@@ -191,9 +191,7 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
         self.clinvar_rating = (star_rating, review_status)
 
         # Populate mode of inheritance (if present)
-        mode_of_inheritance = clinvar_record.mode_of_inheritance
-        if mode_of_inheritance:
-            self.mode_of_inheritance = mode_of_inheritance
+        self.mode_of_inheritance = clinvar_record.mode_of_inheritance
 
     @property
     def db_xref_url(self):
@@ -310,7 +308,8 @@ class CTTVGeneticsEvidenceString(CTTVEvidenceString):
 
     @mode_of_inheritance.setter
     def mode_of_inheritance(self, mode_of_inheritance):
-        self['evidence']['variant2disease']['mode_of_inheritance'] = mode_of_inheritance
+        if mode_of_inheritance:
+            self['evidence']['variant2disease']['mode_of_inheritance'] = mode_of_inheritance
 
 
 class CTTVSomaticEvidenceString(CTTVEvidenceString):


### PR DESCRIPTION
Closes #123. This PR is built on top of #148 and includes all changes from it. See https://github.com/opentargets/platform/issues/1140 for more details.

Mode of inheritance, where present, is now parsed from ClinVar data and included into the evidence strings. This is only possible for `genetic_association` evidence strings and not for somatic mutations (see https://github.com/opentargets/platform/issues/1140#issuecomment-683861830). Importantly, there may be several modes of inheritance per ClinVar record, which is reflected in the code changes.

Also submitted a PR to adjust OT JSON schema, details over there: opentargets/json_schema/pull/97.