### PR TITLE
EVA-2378 — Refactor the quality control system

### DIFF
--- a/.idea/dictionaries/ktsukanov.xml
+++ b/.idea/dictionaries/ktsukanov.xml
@@ -40,6 +40,7 @@
       <w>trinucleotide</w>
       <w>unhashable</w>
       <w>vaccession</w>
+      <w>zooma</w>
     </words>
   </dictionary>
 </component>

--- a/.idea/dictionaries/ktsukanov.xml
+++ b/.idea/dictionaries/ktsukanov.xml
@@ -24,6 +24,7 @@
       <w>htslib</w>
       <w>intron</w>
       <w>introns</w>
+      <w>iupac</w>
       <w>libbz</w>
       <w>liblzma</w>
       <w>licensable</w>

--- a/bin/traits_to_zooma_format.py
+++ b/bin/traits_to_zooma_format.py
@@ -49,13 +49,13 @@ def process_clinvar_record(clinvar_record, outfile):
                    if variant_id is not None]
     traits = clinvar_record.traits
     for variant_id, trait in itertools.product(variant_ids, traits):
-        if (trait.preferred_or_other_name is None) or (trait.preferred_or_other_name.lower() == 'not provided'):
+        if trait.preferred_or_other_valid_name is None:
             continue
         for db, identifier, status in trait.xrefs:
             if status != 'current' or db.lower() not in OntologyUri.db_to_uri_conversion:
                 continue
             ontology_uri = OntologyUri(identifier, db)
-            write_zooma_record(clinvar_record.accession, variant_id, trait.preferred_or_other_name, ontology_uri,
+            write_zooma_record(clinvar_record.accession, variant_id, trait.preferred_or_other_valid_name, ontology_uri,
                                strftime('%d/%m/%y %H:%M', gmtime()), outfile)
 
 

--- a/eva_cttv_pipeline/clinvar_xml_utils.py
+++ b/eva_cttv_pipeline/clinvar_xml_utils.py
@@ -150,6 +150,7 @@ class ClinVarRecord:
         """Returns a list of traits associated with the ClinVar record, in the form of Trait objects."""
         return self.trait_set
 
+    @property
     def traits_with_valid_names(self):
         """Returns a list of traits which have at least one valid (potentially resolvable) name."""
         return [trait for trait in self.trait_set if trait.preferred_or_other_valid_name]

--- a/eva_cttv_pipeline/clinvar_xml_utils.py
+++ b/eva_cttv_pipeline/clinvar_xml_utils.py
@@ -188,8 +188,8 @@ class ClinVarTrait:
     # Some trait records in ClinVar contain names which are non-specific and cannot possibly be resolved to any
     # meaningful EFO term.
     NONSPECIFIC_TRAITS = {
-        '', 'disease', 'not provided', 'not specified', 'reclassified - variant of unknown significance', 'see cases',
-        'variant of unknown significance'
+        '', 'allhighlypenetrant', 'disease', 'not provided', 'not specified',
+        'reclassified - variant of unknown significance', 'see cases', 'variant of unknown significance'
     }
 
     def __init__(self, trait_xml, clinvar_record):
@@ -209,7 +209,7 @@ class ClinVarTrait:
     def all_valid_names(self):
         """Returns a lexicographically sorted list of all valid trait names. A valid name is defined as something which
         is not contained in the list of nonspecific traits, which cannot possibly be resolved to a valid EFO mapping."""
-        return [name for name in self.all_names if name not in self.NONSPECIFIC_TRAITS]
+        return [name for name in self.all_names if name.lower() not in self.NONSPECIFIC_TRAITS]
 
     @property
     def preferred_name(self):
@@ -220,7 +220,7 @@ class ClinVarTrait:
     @property
     def preferred_or_other_valid_name(self):
         """Returns a consistent valid name for a trait, if one is present."""
-        if self.preferred_name and self.preferred_name not in self.NONSPECIFIC_TRAITS:
+        if self.preferred_name and self.preferred_name.lower() not in self.NONSPECIFIC_TRAITS:
             return self.preferred_name
         elif self.all_valid_names:
             return self.all_valid_names[0]

--- a/eva_cttv_pipeline/clinvar_xml_utils.py
+++ b/eva_cttv_pipeline/clinvar_xml_utils.py
@@ -213,7 +213,7 @@ class ClinVarTrait:
 
     @property
     def preferred_name(self):
-        """Returns a single preferred name, as incidated in the ClinVar record."""
+        """Returns a single preferred name, as indicated in the ClinVar record."""
         name = find_optional_unique_element(self.trait_xml, './Name/ElementValue[@Type="Preferred"]')
         return None if name is None else name.text
 

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -13,10 +13,10 @@ from eva_cttv_pipeline.evidence_string_generation import consequence_type as CT
 
 logger = logging.getLogger(__package__)
 
-# A regular expression to detect alleles with IUPAC ambiguity bases
+# A regular expression to detect alleles with IUPAC ambiguity bases.
 IUPAC_AMBIGUOUS_SEQUENCE = re.compile(r'[^ACGT]')
 
-# Output file names
+# Output file names.
 EVIDENCE_STRINGS_FILE_NAME = 'evidence_strings.json'
 EVIDENCE_RECORDS_FILE_NAME = 'evidence_records.tsv'
 UNMAPPED_TRAITS_FILE_NAME = 'unmapped_traits.tsv'
@@ -28,10 +28,10 @@ class Report:
     def __init__(self, trait_mappings, consequence_mappings):
         self.report_strings = []
 
-        # The main evidence string counter
+        # The main evidence string counter.
         self.evidence_string_count = 0
 
-        # ClinVar record counters
+        # ClinVar record counters.
         self.clinvar_total = 0
         self.clinvar_fatal_no_allele_origin = 0
         self.clinvar_fatal_no_valid_traits = 0
@@ -41,14 +41,14 @@ class Report:
         self.clinvar_done_one_evidence_string = 0
         self.clinvar_done_multiple_evidence_strings = 0
 
-        # Total number of trait-to-ontology mappings present in the database
+        # Total number of trait-to-ontology mappings present in the database.
         self.total_trait_mappings = sum([len(mappings) for mappings in trait_mappings.values()])
-        # All distinct (trait name, EFO ID) mappings used in the evidence strings
+        # All distinct (trait name, EFO ID) mappings used in the evidence strings.
         self.used_trait_mappings = set()
-        # All unmapped trait names which prevented evidence string generation and their counts
+        # All unmapped trait names which prevented evidence string generation and their counts.
         self.unmapped_trait_names = Counter()
 
-        # Variant-to-consequence mapping counts
+        # Variant-to-consequence mapping counts.
         self.total_consequence_mappings = sum([len(mappings) for mappings in consequence_mappings.values()])
         self.repeat_expansion_variants = 0
 
@@ -60,7 +60,7 @@ class Report:
         ]) + '\n'
 
     def collate_report(self):
-        # ClinVar tallies
+        # ClinVar tallies.
         clinvar_fatal = self.clinvar_fatal_no_allele_origin + self.clinvar_fatal_no_valid_traits
         clinvar_skipped = (self.clinvar_skip_unsupported_variation + self.clinvar_skip_no_functional_consequences +
                            self.clinvar_skip_missing_efo_mapping)
@@ -187,11 +187,11 @@ def clinvar_to_evidence_strings(string_to_efo_mappings, variant_to_gene_mappings
             evidence_string = generate_evidence_string(clinvar_record, allele_origins, disease_name, disease_source_id,
                                                        disease_mapped_efo_id, consequence_attributes)
 
-            # Validate and immediately output the evidence string (not keeping everything in memory)
+            # Validate and immediately output the evidence string (not keeping everything in memory).
             validate_evidence_string(evidence_string, ot_schema_contents)
             output_evidence_strings_file.write(json.dumps(evidence_string) + '\n')
 
-            # Record some evidence string and trait metrics
+            # Record some evidence string and trait metrics.
             evidence_strings_generated += 1
             report.used_trait_mappings.add((disease_name, disease_mapped_efo_id))
 
@@ -238,25 +238,25 @@ def generate_evidence_string(clinvar_record, allele_origins, disease_name, disea
         # VARIANT ATTRIBUTES.
         'targetFromSourceId': consequence_attributes.ensembl_gene_id,
         'variantFunctionalConsequenceId': consequence_attributes.so_term.accession,
-        'variantId': clinvar_record.measure.vcf_full_coords,  # CHROM_POS_REF_ALT notation
+        'variantId': clinvar_record.measure.vcf_full_coords,  # CHROM_POS_REF_ALT notation.
         'variantRsId': clinvar_record.measure.rs_id,
 
         # PHENOTYPE ATTRIBUTES.
-        # The alphabetical list of *all* disease names from that ClinVar record
+        # The alphabetical list of *all* disease names from that ClinVar record.
         'cohortPhenotypes': sorted([trait.preferred_or_other_valid_name for trait in clinvar_record.traits
                                     if trait.preferred_or_other_valid_name is not None]),
 
-        # One disease name for this evidence string (see group_diseases_by_efo_mapping)
+        # One disease name for this evidence string (see group_diseases_by_efo_mapping).
         'diseaseFromSource': disease_name,
 
-        # The internal identifier of that disease
+        # The internal identifier of that disease.
         'diseaseFromSourceId': disease_source_id,
 
         # The EFO identifier to which we mapped that first disease. Converting the URI to a compact representation as
         # required by the Open Targets JSON schema.
         'diseaseFromSourceMappedId': disease_mapped_efo_id.split('/')[-1],
     }
-    # Remove the attributes with empty values (either None or empty lists)
+    # Remove the attributes with empty values (either None or empty lists).
     evidence_string = {key: value for key, value in evidence_string.items() if value}
     return evidence_string
 
@@ -294,10 +294,10 @@ def get_consequence_types(clinvar_record_measure, consequence_type_dict):
     # If RCV is not present in the consequences file, pair using full variant description (CHROM:POS:REF:ALT)
     if clinvar_record_measure.has_complete_coordinates:
         # This VCF-flavoured identifier is used to pair ClinVar records with functional consequence predictions.
-        # Example of such an identifier: 14:23423715:G:A
+        # Example of such an identifier: 14:23423715:G:A.
         coord_id = ':'.join([clinvar_record_measure.chr, str(clinvar_record_measure.vcf_pos),
                              clinvar_record_measure.vcf_ref, clinvar_record_measure.vcf_alt])
-        # Log unusual variants with IUPAC ambiguity symbols. Example: 12_32625716_G_H (from RCV000032000)
+        # Log unusual variants with IUPAC ambiguity symbols. Example: 12_32625716_G_H (from RCV000032000).
         if IUPAC_AMBIGUOUS_SEQUENCE.search(clinvar_record_measure.vcf_ref + clinvar_record_measure.vcf_alt):
             logger.warning(f'Observed variant with non-ACGT allele sequences: {coord_id}')
         if coord_id in consequence_type_dict:
@@ -376,15 +376,15 @@ def group_diseases_by_efo_mapping(clinvar_record_traits, string_to_efo_mappings)
         * (E, MedGen_E, EFO_4)
         * (E, MedGen_E, EFO_5)"""
 
-    # Group traits by their EFO mappings and explode multiple mappings
-    efo_to_traits = defaultdict(list)  # Key: EFO ID, value: list of traits mapped to that ID
+    # Group traits by their EFO mappings and explode multiple mappings.
+    efo_to_traits = defaultdict(list)  # Key: EFO ID, value: list of traits mapped to that ID.
     for trait in clinvar_record_traits:
         # Try to match using all trait names.
         for trait_name in trait.all_names:
             for efo_id, efo_label in string_to_efo_mappings.get(trait_name.lower(), []):
                 efo_to_traits[efo_id].append(trait)
 
-    # Generate tuples by keeping only one disease from each group
+    # Generate tuples by keeping only one disease from each group.
     grouped_tuples = []
     for efo_id, traits in efo_to_traits.items():
         traits = sorted(traits, key=lambda t: t.preferred_or_other_valid_name)

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -268,8 +268,8 @@ def generate_evidence_string(clinvar_record, allele_origins, disease_name, disea
 
         # PHENOTYPE ATTRIBUTES.
         # The alphabetical list of *all* disease names from that ClinVar record
-        'cohortPhenotypes': sorted([trait.preferred_or_other_name for trait in clinvar_record.traits
-                                    if trait.preferred_or_other_name is not None]),
+        'cohortPhenotypes': sorted([trait.preferred_or_other_valid_name for trait in clinvar_record.traits
+                                    if trait.preferred_or_other_valid_name is not None]),
 
         # One disease name for this evidence string (see group_diseases_by_efo_mapping)
         'diseaseFromSource': disease_name,
@@ -419,7 +419,7 @@ def group_diseases_by_efo_mapping(clinvar_record_traits, string_to_efo_mappings)
     # Generate tuples by keeping only one disease from each group
     grouped_tuples = []
     for efo_id, traits in efo_to_traits.items():
-        traits = sorted(traits, key=lambda t: t.preferred_or_other_name)
+        traits = sorted(traits, key=lambda t: t.preferred_or_other_valid_name)
         selected_trait = traits[0]
-        grouped_tuples.append((selected_trait.preferred_or_other_name, selected_trait.medgen_id, efo_id))
+        grouped_tuples.append((selected_trait.preferred_or_other_valid_name, selected_trait.medgen_id, efo_id))
     return grouped_tuples

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -128,7 +128,8 @@ def clinvar_to_evidence_strings(string_to_efo_mappings, variant_to_gene_mappings
         if report.clinvar_total % 1000 == 0:
             logger.info(f'{report.clinvar_total} records processed')
         if clinvar_record.measure and clinvar_record.measure.is_repeat_expansion_variant:
-            report.repeat_expansion_variants += 1
+            report.repeat_expansion_variants += len(get_consequence_types(clinvar_record.measure,
+                                                                          variant_to_gene_mappings))
 
         # Failure mode 1 (fatal). A ClinVar record contains no allele origin.
         if not clinvar_record.allele_origins:

--- a/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
+++ b/eva_cttv_pipeline/evidence_string_generation/clinvar_to_evidence_strings.py
@@ -52,13 +52,6 @@ class Report:
         self.total_consequence_mappings = sum([len(mappings) for mappings in consequence_mappings.values()])
         self.repeat_expansion_variants = 0
 
-    @staticmethod
-    def generate_report_from_lines(lines):
-        return '\n'.join([
-            '\t'.join([str(field) for field in line])
-            for line in lines
-        ]) + '\n'
-
     def collate_report(self):
         # ClinVar tallies.
         clinvar_fatal = self.clinvar_fatal_no_allele_origin + self.clinvar_fatal_no_valid_traits
@@ -68,34 +61,30 @@ class Report:
         assert clinvar_fatal + clinvar_skipped + clinvar_done == self.clinvar_total, \
             'ClinVar evidence string tallies do not add up to the total amount.'
 
-        lines = [
-            ('Total number of evidence strings generated', self.evidence_string_count),
-            (),
-            ('Total number of ClinVar records', self.clinvar_total),
-            ('    Fatal: Cannot be processed ever', f'{clinvar_fatal}'),
-            ('        No allele origin', self.clinvar_fatal_no_allele_origin),
-            ('        No traits with valid names', self.clinvar_fatal_no_valid_traits),
-            ('    Skipped: Can be rescued by future improvements', f'{clinvar_skipped}'),
-            ('        Unsupported variation type', self.clinvar_skip_unsupported_variation),
-            ('        No functional consequences', self.clinvar_skip_no_functional_consequences),
-            ('        Missing EFO mapping', self.clinvar_skip_missing_efo_mapping),
-            ('    Done: Generated at least one evidence string', f'{clinvar_done}'),
-            ('        One evidence string', self.clinvar_done_one_evidence_string),
-            ('        Multiple evidence strings', self.clinvar_done_multiple_evidence_strings),
-            ('Percentage of all potentially supportable ClinVar records which generated at least one evidence string',
-             f'{clinvar_done / (clinvar_skipped + clinvar_done):.1%}'),
-            (),
-            ('Total number of trait-to-ontology mappings in the database', self.total_trait_mappings),
-            ('    The number of distinct trait-to-ontology mappings used in the evidence strings',
-             len(self.used_trait_mappings)),
-            ('The number of distinct unmapped trait names which prevented evidence string generation',
-             len(self.unmapped_trait_names)),
-            (),
-            ('Total number of variant to consequence mappings', self.total_consequence_mappings),
-            ('    Number of repeat expansion variants', self.repeat_expansion_variants),
-        ]
+        return f'''Total number of evidence strings generated\t{self.evidence_string_count}
 
-        return self.generate_report_from_lines(lines)
+            Total number of ClinVar records\t{self.clinvar_total}
+                Fatal: Cannot be processed ever\t{clinvar_fatal}
+                    No allele origin\t{self.clinvar_fatal_no_allele_origin}
+                    No traits with valid names\t{self.clinvar_fatal_no_valid_traits}
+                Skipped: Can be rescued by future improvements\t{clinvar_skipped}
+                    Unsupported variation type\t{self.clinvar_skip_unsupported_variation}
+                    No functional consequences\t{self.clinvar_skip_no_functional_consequences}
+                    Missing EFO mapping\t{self.clinvar_skip_missing_efo_mapping}
+                Done: Generated at least one evidence string\t{clinvar_done}
+                    One evidence string\t{self.clinvar_done_one_evidence_string}
+                    Multiple evidence strings\t{self.clinvar_done_multiple_evidence_strings}
+            Percentage of all potentially supportable ClinVar records which generated at least one evidence string\t{
+                clinvar_done / (clinvar_skipped + clinvar_done):.1%}
+
+            Total number of trait-to-ontology mappings in the database\t{self.total_trait_mappings}
+                The number of distinct trait-to-ontology mappings used in the evidence strings\t{
+                    len(self.used_trait_mappings)}
+            The number of distinct unmapped trait names which prevented evidence string generation\t{
+                len(self.unmapped_trait_names)}
+
+            Total number of variant to consequence mappings\t{self.total_consequence_mappings}
+                Number of repeat expansion variants\t{self.repeat_expansion_variants}'''.replace('\n' + ' ' * 12, '\n')
 
     def write_unmapped_terms(self, dir_out):
         with open(os.path.join(dir_out, UNMAPPED_TRAITS_FILE_NAME), 'w') as unmapped_traits_file:

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import multiprocessing
 
+from eva_cttv_pipeline.clinvar_xml_utils import ClinVarTrait
 from eva_cttv_pipeline.trait_mapping.output import output_trait
 from eva_cttv_pipeline.trait_mapping.oxo import get_oxo_results
 from eva_cttv_pipeline.trait_mapping.oxo import uris_to_oxo_format
@@ -13,9 +14,7 @@ from eva_cttv_pipeline.trait_mapping.zooma import get_zooma_results
 logger = logging.getLogger(__package__)
 
 # These ambiguous trait names cannot be resolved to a specific disease and must not be output
-# TODO: Also use this in the future refactor of the quality control system (see issue #114)
-NONSPECIFIC_TRAITS = {'disease', 'not provided', 'not specified', 'reclassified - variant of unknown significance',
-                      'see cases', 'variant of unknown significance'}
+NONSPECIFIC_TRAITS = ClinVarTrait.NONSPECIFIC_TRAITS
 
 
 def get_uris_for_oxo(zooma_result_list: list) -> set:

--- a/eva_cttv_pipeline/trait_mapping/main.py
+++ b/eva_cttv_pipeline/trait_mapping/main.py
@@ -10,11 +10,7 @@ from eva_cttv_pipeline.trait_mapping.trait import Trait
 from eva_cttv_pipeline.trait_mapping.trait_names_parsing import parse_trait_names
 from eva_cttv_pipeline.trait_mapping.zooma import get_zooma_results
 
-
 logger = logging.getLogger(__package__)
-
-# These ambiguous trait names cannot be resolved to a specific disease and must not be output
-NONSPECIFIC_TRAITS = ClinVarTrait.NONSPECIFIC_TRAITS
 
 
 def get_uris_for_oxo(zooma_result_list: list) -> set:
@@ -95,7 +91,7 @@ def main(input_filepath, output_mappings_filepath, output_curation_filepath, fil
         logger.info('Writing output with the processed traits')
         for trait in processed_trait_list:
             # Remove non-specific trait names which should never be output
-            if trait.name.lower() not in NONSPECIFIC_TRAITS:
+            if trait.name.lower() not in ClinVarTrait.NONSPECIFIC_TRAITS:
                 output_trait(trait, mapping_writer, curation_writer)
 
     logger.info('Finished processing trait names')

--- a/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
+++ b/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
@@ -28,7 +28,8 @@ def parse_trait_names(filepath: str) -> list:
     nt_expansion_traits = set()
 
     for clinvar_record in clinvar_xml_utils.ClinVarDataset(filepath):
-        trait_names = set(trait.preferred_or_other_valid_name.lower() for trait in clinvar_record.traits_with_valid_names)
+        trait_names = set(trait.preferred_or_other_valid_name.lower()
+                          for trait in clinvar_record.traits_with_valid_names)
         for trait_name in trait_names:
             trait_name_counter[trait_name] += 1
         if clinvar_record.measure and clinvar_record.measure.is_repeat_expansion_variant:

--- a/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
+++ b/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
@@ -28,7 +28,7 @@ def parse_trait_names(filepath: str) -> list:
     nt_expansion_traits = set()
 
     for clinvar_record in clinvar_xml_utils.ClinVarDataset(filepath):
-        trait_names = set(trait.preferred_or_other_valid_name.lower() for trait in clinvar_record.valid_traits)
+        trait_names = set(trait.preferred_or_other_valid_name.lower() for trait in clinvar_record.traits_with_valid_names)
         for trait_name in trait_names:
             trait_name_counter[trait_name] += 1
         if clinvar_record.measure and clinvar_record.measure.is_repeat_expansion_variant:

--- a/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
+++ b/eva_cttv_pipeline/trait_mapping/trait_names_parsing.py
@@ -28,8 +28,7 @@ def parse_trait_names(filepath: str) -> list:
     nt_expansion_traits = set()
 
     for clinvar_record in clinvar_xml_utils.ClinVarDataset(filepath):
-        trait_names = set(trait.preferred_or_other_name.lower() for trait in clinvar_record.traits
-                          if trait.preferred_or_other_name is not None)
+        trait_names = set(trait.preferred_or_other_valid_name.lower() for trait in clinvar_record.valid_traits)
         for trait_name in trait_names:
             trait_name_counter[trait_name] += 1
         if clinvar_record.measure and clinvar_record.measure.is_repeat_expansion_variant:

--- a/tests/evidence_string_generation/test_clinvar.py
+++ b/tests/evidence_string_generation/test_clinvar.py
@@ -25,7 +25,8 @@ class TestClinvarRecord(unittest.TestCase):
 
     def test_traits(self):
         self.assertEqual(self.test_clinvar_record.traits[0].preferred_name, 'Leber congenital amaurosis 13')
-        self.assertEqual(self.test_clinvar_record.traits[0].preferred_or_other_name, 'Leber congenital amaurosis 13')
+        self.assertEqual(self.test_clinvar_record.traits[0].preferred_or_other_valid_name,
+                         'Leber congenital amaurosis 13')
 
     def test_trait_pubmed_refs(self):
         self.assertEqual(self.test_clinvar_record.traits[0].pubmed_refs, [20301475, 20301590, 30285347])


### PR DESCRIPTION
Unified the list of nonspecific trait names: things like “disease”, “not provided”, “not specified” etc.—in other words, something which cannot be _possibly_ mapped to anything sensible.

Based on this change, introduced two new concepts:
* `preferred_or_other_valid_name` is a sensible, consistent name for a given ClinVarTrait. It works like this:
  + If there is a preferred name, and it's not in the blacklist of nonspecific names, use that one;
  + Otherwise, if there are any other (non-preferred) names which are not in the blacklist, use the first one alphabetically;
  + Otherwise, return None.
* Consequently, `traits_with_valid_names` of a ClinVarRecord contains the list of only those traits which have `preferred_or_other_name` defined.

Completely refactored the reporting system and [**the quality metric spreadsheet**](https://docs.google.com/spreadsheets/d/1g_4tHNWP4VIikH7Jb0ui5aNr0PiFgvscZYOe69g191k/). Each ClinVar record is now tracked to exactly one of seven possible outcomes:
* Two fatal failure modes (something we cannot possibly convert into an evidence string),
* Three “skip” failure modes (something we can possibly improve in the future),
* Two success modes (generated one or multiple evidence strings).

Metrics related to trait mappings and functional consequence mappings have been renamed and reoganised for clarity.

Closes #108 (upon inspection, no unused modules were found). Closes #114.