### PR TITLE
ISSUE-215: strip white spaces from ontology identifiers

### DIFF
--- a/eva_cttv_pipeline/clinvar_xml_utils.py
+++ b/eva_cttv_pipeline/clinvar_xml_utils.py
@@ -235,7 +235,7 @@ class ClinVarTrait:
 
     @property
     def xrefs(self):
-        return [(elem.attrib['DB'], elem.attrib['ID'], elem.attrib.get('Status', 'current').lower())
+        return [(elem.attrib['DB'], elem.attrib['ID'].strip(), elem.attrib.get('Status', 'current').lower())
                 for elem in find_elements(self.trait_xml, './XRef')]
 
     @property


### PR DESCRIPTION
The ontology URIs in `clinvar-xrefs.txt` had spaces in them incorrectly. From looking at the code I think this must be because of extra whitespace in the clinvar XML data. To solve this problem, strip any leading or trailing whitespace from the ontology ID so that when we combine it with the URI for that ontology, there should not be any spaces in the middle.

Fixes #215.