### PR TITLE
ISSUE-203 - Duplication checks and documentation

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -95,5 +95,19 @@ And then one of:
 * To install to develop: `python3 setup.py develop`
 * To build a source distribution: `python3 setup.py sdist`
 
+## JQ Installation
+``jq`` is a lightweight and flexible command-line JSON processor, used to parse the evidence strings and extract specific fields to check for duplicates.
+
+To install it you can:
+* Either run the specific installation command (e.g. ``sudo apt-get install jq`` for Ubuntu) for your operating system (search for yours [here](https://stedolan.github.io/jq/download/)).
+* Directly download it (since it has no runtime dependencies) and export its path:
+````bash
+JQ_INSTALL_PATH="/nfs/production3/eva/software/jq/1.6"
+JQ_DOWNLOAD_VERSION="https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
+mkdir -p ${JQ_INSTALL_PATH}
+wget -O ${JQ_INSTALL_PATH}/jq ${JQ_DOWNLOAD_VERSION}
+export PATH="${JQ_INSTALL_PATH}:$PATH"
+````
+
 ## Tests
 You can run all tests with: `python3 setup.py test`

--- a/docs/generate-evidence-strings.md
+++ b/docs/generate-evidence-strings.md
@@ -79,9 +79,8 @@ ${BSUB_CMDLINE} -K -M 10G \
     --ot-schema    ${BATCH_ROOT}/evidence_strings/opentargets-${OT_SCHEMA_VERSION}.json \
     --out          ${BATCH_ROOT}/evidence_strings/
 
-# Check that the generated evidence strings do not contain any duplicates
-sort ${BATCH_ROOT}/evidence_strings/evidence_strings.json | uniq -c | awk '$1 > 1' > \
-  ${BATCH_ROOT}/evidence_strings/duplicates.json
+# Check that the generated evidence strings do not contain any duplicated evidence strings (fields: datatypeId, studyId, targetFromSourceId, variantFunctionalConsequenceId and diseaseFromSourceMappedId)
+grep -oP '(?<=(datatypeId\"\: ")|(studyId\"\: ")|(targetFromSourceId\"\: ")|(variantFunctionalConsequenceId\"\: ")|(diseaseFromSourceMappedId\"\: \"))[^\"]*' ${BATCH_ROOT}/evidence_strings/evidence_strings.json | paste - - - - - | sort | uniq -d > ${BATCH_ROOT}/evidence_strings/duplicates.json
 
 # Convert MedGen and OMIM cross-references into ZOOMA format.
 ${BSUB_CMDLINE} -K \
@@ -96,6 +95,14 @@ ${BSUB_CMDLINE} -K \
 
 ### Check that generated evidence strings do not contain any duplicates
 The algorithm used for generating the evidence strings should not allow any duplicate values to be emitted, and the file `${BATCH_ROOT}/evidence_strings/duplicates.json` should be empty. Check that this is the case.
+
+A repeated evidence string will have identical values for these five fields:
+* **datatypeId** - Identifier of the type of data we are associating, varying between somatic and non-somatic ClinVar records (*e.g.* ``somatic_mutation`` or ``genetic_association`` respectively). 
+* **studyId** - Reference ClinVar record (*e.g.* ``RCV000015714``).
+* **targetFromSourceId** - The gene affected by the variant (*e.g.* ``ENSG00000186832``). 
+* **variantFunctionalConsequenceId** - The consequence of such variant (*e.g.* ``SO_0001818``, which corresponds to protein_altering_variant). 
+* **diseaseFromSourceMappedId** - Associated phenotype to such variant (*e.g.* ``Orphanet_2337``, which corresponds to a type of keratoderma). 
+
 
 ### Update summary metrics
 After the evidence strings have been generated, summary metrics need to be updated in the Google Sheets [table](https://docs.google.com/spreadsheets/d/1g_4tHNWP4VIikH7Jb0ui5aNr0PiFgvscZYOe69g191k/) on the “Raw statistics” sheet.

--- a/docs/generate-evidence-strings.md
+++ b/docs/generate-evidence-strings.md
@@ -79,8 +79,11 @@ ${BSUB_CMDLINE} -K -M 10G \
     --ot-schema    ${BATCH_ROOT}/evidence_strings/opentargets-${OT_SCHEMA_VERSION}.json \
     --out          ${BATCH_ROOT}/evidence_strings/
 
-# Check that the generated evidence strings do not contain any duplicated evidence strings (fields: datatypeId, studyId, targetFromSourceId, variantFunctionalConsequenceId and diseaseFromSourceMappedId)
-grep -oP '(?<=(datatypeId\"\: ")|(studyId\"\: ")|(targetFromSourceId\"\: ")|(variantFunctionalConsequenceId\"\: ")|(diseaseFromSourceMappedId\"\: \"))[^\"]*' ${BATCH_ROOT}/evidence_strings/evidence_strings.json | paste - - - - - | sort | uniq -d > ${BATCH_ROOT}/evidence_strings/duplicates.json
+# Check that the generated evidence strings do not contain any duplicated evidence strings. For every evidence string, we group the value of fields datatypeId, studyId, targetFromSourceId, variantFunctionalConsequenceId and diseaseFromSourceMappedId, all separated by tabs, sorted and saved at duplicates.json if found duplicated. 
+jq --arg sep $'\t' -jr \
+  '.datatypeId,$sep,.studyId,$sep,.targetFromSourceId,$sep,.variantFunctionalConsequenceId,$sep,.diseaseFromSourceMappedId,"\n"' \
+  ${BATCH_ROOT}/evidence_strings/evidence_strings.json \
+  | sort | uniq -d > ${BATCH_ROOT}/evidence_strings/duplicates.json
 
 # Convert MedGen and OMIM cross-references into ZOOMA format.
 ${BSUB_CMDLINE} -K \


### PR DESCRIPTION
Closes #203.

Modified the README containing the protocols to generate evidence strings:
* Replaced the previous command with the new one, stricter, that checks for the 5 repeated fields. I used `Positive LookBehind` and regex with `grep`  for this, since I could not find a `JSON` parser within ``noah-login-02``. 
* Added what we consider a duplicated evidence string within the same README. If you feel like this documentation should not be within the protocol, let me know where to place it: duplication of evidence strings was not mentioned elsewhere. 