### PR TITLE
Add splicing variant consequence to severity_ranking.txt

### DIFF
--- a/consequence_prediction/vep_mapping_pipeline/severity_ranking.txt
+++ b/consequence_prediction/vep_mapping_pipeline/severity_ranking.txt
@@ -2,8 +2,8 @@ transcript_ablation
 splice_acceptor_variant
 splice_polypyrimidine_tract_variant
 splice_donor_variant
-splice_donor_5th_base_variant
 splice_donor_region_variant
+splice_donor_5th_base_variant
 stop_gained
 frameshift_variant
 stop_lost

--- a/consequence_prediction/vep_mapping_pipeline/severity_ranking.txt
+++ b/consequence_prediction/vep_mapping_pipeline/severity_ranking.txt
@@ -1,6 +1,9 @@
 transcript_ablation
 splice_acceptor_variant
+splice_polypyrimidine_tract_variant
 splice_donor_variant
+splice_donor_5th_base_variant
+splice_donor_region_variant
 stop_gained
 frameshift_variant
 stop_lost


### PR DESCRIPTION
The [original documentation](https://m.ensembl.org/info/genome/variation/prediction/predicted_data.html) has not been updated so I had to guess if the more specific consequence (splice_donor_5th_base_variant) were placed above or bellow the more general ones (splice_donor_variant).
For now I have preferred to set them bellow to ensure continuity of results. But that could be changed now or latter.
closes #296 